### PR TITLE
Introduce Named Children

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rusttyc"
-version = "0.5.0"
-authors = ["Maximilian Schwenger <maximilian.schwenger@cispa.de>"]
+version = "0.6.0"
+authors = ["Maximilian Schwenger <maximilian.schwenger@cispa.de>", "Florian Kohn <florian.kohn@cispa.de>"]
 edition = "2018"
 license = "MIT"
 description = "A library for writing type checkers with a lattice-like type system in rust."

--- a/examples/parametrized_function.rs
+++ b/examples/parametrized_function.rs
@@ -55,7 +55,7 @@ impl TcVariant for Variant {
         Ok(Partial { variant, children: ChildConstraint::Indexed(0) })
     }
 
-    fn arity(&self) -> Arity {
+    fn arity(&self) -> Arity<String> {
         Arity::FixedIndexed(0)
     }
 }

--- a/examples/parametrized_function.rs
+++ b/examples/parametrized_function.rs
@@ -1,3 +1,4 @@
+use rusttyc::types::{ChildConstraint, ResolvedChildren};
 use rusttyc::{
     types::Arity, Constructable, Partial, TcErr, TcKey, TcVar, TypeChecker, Variant as TcVariant, VarlessTypeChecker,
 };
@@ -37,8 +38,8 @@ impl TcVariant for Variant {
 
     fn meet(lhs: Partial<Self>, rhs: Partial<Self>) -> Result<Partial<Self>, Self::Err> {
         use Variant::*;
-        assert_eq!(lhs.least_arity, 0, "spurious child");
-        assert_eq!(rhs.least_arity, 0, "spurious child");
+        assert_eq!(lhs.children.len(), 0, "spurious child");
+        assert_eq!(rhs.children.len(), 0, "spurious child");
         let variant = match (lhs.variant, rhs.variant) {
             (Any, other) | (other, Any) => Ok(other),
             (Integer(l), Integer(r)) => Ok(Integer(max(r, l))),
@@ -51,11 +52,11 @@ impl TcVariant for Variant {
             (Numeric, Fixed(i, f)) | (Fixed(i, f), Numeric) => Ok(Fixed(i, f)),
             (Numeric, Numeric) => Ok(Numeric),
         }?;
-        Ok(Partial { variant, least_arity: 0 })
+        Ok(Partial { variant, children: ChildConstraint::Indexed(0) })
     }
 
     fn arity(&self) -> Arity {
-        Arity::Fixed(0)
+        Arity::FixedIndexed(0)
     }
 }
 
@@ -99,8 +100,8 @@ enum Expression {
 impl Constructable for Variant {
     type Type = Type;
 
-    fn construct(&self, children: &[Self::Type]) -> Result<Self::Type, Self::Err> {
-        assert!(children.is_empty(), "spurious children");
+    fn construct(&self, children: ResolvedChildren<Type>) -> Result<Self::Type, Self::Err> {
+        assert!(matches!(children, ResolvedChildren::None), "spurious children");
         use Variant::*;
         match self {
             Any => Err("Cannot reify `Any`.".to_string()),
@@ -146,7 +147,6 @@ fn tc_expr(tc: &mut VarlessTypeChecker<Variant>, expr: &Expression) -> Result<Tc
             // would copy the keys rather than creating new ones.
             let params: Vec<(Option<Variant>, TcKey)> =
                 param_constraints.iter().map(|p| (*p, tc.new_term_key())).collect();
-            &params;
             for (arg_ty, arg_expr) in args {
                 let arg_key = tc_expr(tc, arg_expr)?;
                 match arg_ty {

--- a/src/constraint_graph.rs
+++ b/src/constraint_graph.rs
@@ -253,7 +253,6 @@ impl<V: ContextSensitiveVariant> Type<V> {
         let mut no_children = false;
 
         // println!("Meeting: {:?} and {:?}", lhs, rhs);
-        dbg!(&lhs.children, &rhs.children, &lhs.variant.arity(ctx), &rhs.variant.arity(ctx));
 
         match (&lhs.children, &rhs.children) {
             (Children::Indexed(_), Children::Named(_)) | (Children::Named(_), Children::Indexed(_)) => {

--- a/src/constraint_graph.rs
+++ b/src/constraint_graph.rs
@@ -363,10 +363,7 @@ impl<V: ContextSensitiveVariant> Type<V> {
                 .map(|k| {
                     (
                         children_l.get(k).cloned().flatten().zip(children_r.get(k).cloned().flatten()),
-                        (
-                            *k,
-                            children_l.get(k).cloned().flatten().or_else(|| children_r.get(k).cloned().flatten()),
-                        ),
+                        (*k, children_l.get(k).cloned().flatten().or_else(|| children_r.get(k).cloned().flatten())),
                     )
                 })
                 .unzip();

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -47,6 +47,7 @@ pub enum Constraint<V: ContextSensitiveVariant> {
 /// Assume the following data structures exist:
 /// ```
 /// use rusttyc::{Variant, TcKey, TypeChecker, TcVar, TcErr, Partial, Arity};
+/// use rusttyc::types::ChildConstraint;
 ///
 /// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// enum MyVariant {
@@ -69,13 +70,13 @@ pub enum Constraint<V: ContextSensitiveVariant> {
 ///             (UInt, x) | (x, UInt) => Ok(x),       // x can only be UInt or U8.
 ///             (U8, U8) => Ok(U8),
 ///         }?;
-///         Ok(Partial { variant, least_arity: 0 })
+///         Ok(Partial { variant, children: ChildConstraint::Indexed(0) })
 ///     }
 ///     fn top() -> Self {
 ///         Self::Top
 ///     }
 ///     fn arity(&self) -> Arity {
-///         Arity::Fixed(0)
+///         Arity::FixedIndexed(0)
 ///     }
 /// }
 /// #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
@@ -100,6 +101,7 @@ pub enum Constraint<V: ContextSensitiveVariant> {
 ///     type Err = String;
 ///     fn meet(lhs: Partial<Self>, rhs: Partial<Self>) -> Result<Partial<Self>, Self::Err> {
 ///         use MyVariant::*;
+/// use rusttyc::types::ChildConstraint;
 ///         let variant = match (lhs.variant, rhs.variant) {
 ///             (Top, x) | (x, Top) => Ok(x),
 ///             (String, String) => Ok(String),
@@ -108,13 +110,13 @@ pub enum Constraint<V: ContextSensitiveVariant> {
 ///             (UInt, x) | (x, UInt) => Ok(x),       // x can only be UInt or U8.
 ///             (U8, U8) => Ok(U8),
 ///         }?;
-///         Ok(Partial { variant, least_arity: 0 })
+///         Ok(Partial { variant, children: ChildConstraint::Indexed(0) })
 ///     }
 ///     fn top() -> Self {
 ///         Self::Top
 ///     }
 ///     fn arity(&self) -> Arity {
-///         Arity::Fixed(0)
+///         Arity::FixedIndexed(0)
 ///     }
 /// }
 /// #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -75,7 +75,7 @@ pub enum Constraint<V: ContextSensitiveVariant> {
 ///     fn top() -> Self {
 ///         Self::Top
 ///     }
-///     fn arity(&self) -> Arity {
+///     fn arity(&self) -> Arity<String> {
 ///         Arity::None
 ///     }
 /// }
@@ -115,7 +115,7 @@ pub enum Constraint<V: ContextSensitiveVariant> {
 ///     fn top() -> Self {
 ///         Self::Top
 ///     }
-///     fn arity(&self) -> Arity {
+///     fn arity(&self) -> Arity<String> {
 ///         Arity::None
 ///     }
 /// }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -70,13 +70,13 @@ pub enum Constraint<V: ContextSensitiveVariant> {
 ///             (UInt, x) | (x, UInt) => Ok(x),       // x can only be UInt or U8.
 ///             (U8, U8) => Ok(U8),
 ///         }?;
-///         Ok(Partial { variant, children: ChildConstraint::Indexed(0) })
+///         Ok(Partial { variant, children: ChildConstraint::NoChildren })
 ///     }
 ///     fn top() -> Self {
 ///         Self::Top
 ///     }
 ///     fn arity(&self) -> Arity {
-///         Arity::FixedIndexed(0)
+///         Arity::None
 ///     }
 /// }
 /// #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
@@ -110,13 +110,13 @@ pub enum Constraint<V: ContextSensitiveVariant> {
 ///             (UInt, x) | (x, UInt) => Ok(x),       // x can only be UInt or U8.
 ///             (U8, U8) => Ok(U8),
 ///         }?;
-///         Ok(Partial { variant, children: ChildConstraint::Indexed(0) })
+///         Ok(Partial { variant, children: ChildConstraint::NoChildren})
 ///     }
 ///     fn top() -> Self {
 ///         Self::Top
 ///     }
 ///     fn arity(&self) -> Arity {
-///         Arity::FixedIndexed(0)
+///         Arity::None
 ///     }
 /// }
 /// #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //! type MyTypeErr = String;
 //! impl Variant for MyVariant {
 //!     type Err = MyTypeErr;
-//!     fn arity(&self) -> Arity { Arity::FixedIndexed(0) }
+//!     fn arity(&self) -> Arity<String> { Arity::FixedIndexed(0) }
 //!     fn top() -> Self { MyVariant::Top }
 //!     fn meet(lhs: Partial<Self>, rhs: Partial<Self>) -> Result<Partial<Self>, Self::Err> {
 //!         use rusttyc::types::ChildConstraint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,18 +38,19 @@
 //! type MyTypeErr = String;
 //! impl Variant for MyVariant {
 //!     type Err = MyTypeErr;
-//!     fn arity(&self) -> Arity { Arity::Fixed(0) }
+//!     fn arity(&self) -> Arity { Arity::FixedIndexed(0) }
 //!     fn top() -> Self { MyVariant::Top }
 //!     fn meet(lhs: Partial<Self>, rhs: Partial<Self>) -> Result<Partial<Self>, Self::Err> {
-//!         assert_eq!(lhs.least_arity, 0);
-//!         assert_eq!(lhs.least_arity, 0);
+//!         use rusttyc::types::ChildConstraint;
+//! assert_eq!(lhs.children.len(), 0);
+//!         assert_eq!(lhs.children.len(), 0);
 //!         let variant = match (lhs.variant, rhs.variant) {
 //!             (MyVariant::Top, x) | (x, MyVariant::Top) => Ok(x),
 //!             (MyVariant::Boolean, MyVariant::Boolean) => Ok(MyVariant::Boolean),
 //!             (MyVariant::Integer(a), MyVariant::Integer(b)) => Ok(MyVariant::Integer(usize::max(a, b))),
 //!             (MyVariant::Boolean, MyVariant::Integer(_)) | (MyVariant::Integer(_), MyVariant::Boolean) => Err(String::from("Cannot combine Boolean and Integer")),
 //!         }?;
-//!         Ok(Partial { variant, least_arity: 0 })
+//!         Ok(Partial { variant, children: ChildConstraint::Indexed(0) })
 //!     }
 //! }
 //! #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
@@ -78,8 +79,8 @@
 //! Check the RustTyC examples on github for more elaborate examples.
 //!     
 
+// Todo: re-add missing_docs
 #![deny(
-    missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
     trivial_casts,
@@ -88,7 +89,7 @@
     unstable_features,
     unused_import_braces,
     unused_qualifications,
-    broken_intra_doc_links,
+    rustdoc::broken_intra_doc_links,
     unused_results
 )]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,10 +79,10 @@
 //! Check the RustTyC examples on github for more elaborate examples.
 //!     
 
-// Todo: re-add missing_docs
 #![deny(
     missing_debug_implementations,
     missing_copy_implementations,
+    missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unsafe_code,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -57,7 +57,7 @@ impl TcVariant for Variant {
         Ok(Partial { variant, children: ChildConstraint::NoChildren })
     }
 
-    fn arity(&self) -> Arity {
+    fn arity(&self) -> Arity<String> {
         Arity::None
     }
 }
@@ -425,7 +425,7 @@ impl ContextSensitiveVariant for StructVariant {
         Ok(Partial { variant: new_var, children: new_constr })
     }
 
-    fn arity(&self, ctx: &Self::Context) -> Arity {
+    fn arity(&self, ctx: &Self::Context) -> Arity<String> {
         match self {
             StructVariant::Any => Arity::Variable,
             StructVariant::String | StructVariant::Bool | StructVariant::Integer => Arity::None,
@@ -468,7 +468,9 @@ fn test_struct() {
         "Struct1".to_string(),
         HashSet::from(["Hello".to_string(), "World".to_string(), "Test".to_string()]),
     )]);
-    let mut tc: TypeChecker<StructVariant, Variable> = TypeChecker::with_context(structs);
+    let field_names = HashSet::from(["Hello".into(), "World".into(), "Test".into()]);
+    let mut tc: TypeChecker<StructVariant, Variable> =
+        TypeChecker::with_context(structs).define_children_names(field_names);
     let key_a = tc.new_term_key();
     let key_b = tc.new_term_key();
     let key_c = tc.new_term_key();
@@ -509,7 +511,9 @@ fn test_incompatible_children() {
         "Struct1".to_string(),
         HashSet::from(["Hello".to_string(), "World".to_string(), "Test".to_string()]),
     )]);
-    let mut tc: TypeChecker<StructVariant, Variable> = TypeChecker::with_context(structs);
+    let field_names = HashSet::from(["Hello".into(), "World".into(), "Test".into()]);
+    let mut tc: TypeChecker<StructVariant, Variable> =
+        TypeChecker::with_context(structs).define_children_names(field_names);
     let key_a = tc.new_term_key();
     let key_b = tc.new_term_key();
     let key_c = tc.new_term_key();
@@ -537,7 +541,9 @@ fn test_mixed_access() {
         "Struct1".to_string(),
         HashSet::from(["Hello".to_string(), "World".to_string(), "Test".to_string()]),
     )]);
-    let mut tc: TypeChecker<StructVariant, Variable> = TypeChecker::with_context(structs);
+    let field_names = HashSet::from(["Hello".into(), "World".into(), "Test".into()]);
+    let mut tc: TypeChecker<StructVariant, Variable> =
+        TypeChecker::with_context(structs).define_children_names(field_names);
     let key_a = tc.new_term_key();
     let key_b = tc.new_term_key();
     let key_c = tc.new_term_key();
@@ -563,7 +569,9 @@ fn test_mixed_struct_tuple() {
         "Struct1".to_string(),
         HashSet::from(["Hello".to_string(), "World".to_string(), "Test".to_string()]),
     )]);
-    let mut tc: TypeChecker<StructVariant, Variable> = TypeChecker::with_context(structs);
+    let field_names = HashSet::from(["Hello".into(), "World".into(), "Test".into()]);
+    let mut tc: TypeChecker<StructVariant, Variable> =
+        TypeChecker::with_context(structs).define_children_names(field_names);
     let key_a = tc.new_term_key();
     let key_b = tc.new_term_key();
     let key_c = tc.new_term_key();

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -4,7 +4,7 @@ use crate::{
     keys::{Constraint, TcKey},
     types::Preliminary,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::hash::Hash;
 
@@ -202,6 +202,19 @@ pub enum TcErr<V: ContextSensitiveVariant> {
     /// Contains the affected key, its inferred or explicitly assigned variant, and the index of the child that
     /// was attempted to be accessed.
     ChildAccessOutOfBound(TcKey, V, usize),
+    /// This error occurs when a constraint accesses the child with the given name of a type and its variant turns out to
+    /// not know this child.
+    /// Contains the affected key, its inferred or explicitly assigned variant, and the name of the child that
+    /// was attempted to be accessed.
+    FieldDoesNotExist(TcKey, V, HashSet<String>),
+    /// Attempted an named access to a child on a type that has indexed children.
+    /// Contains the affected key, its inferred or explicitly assigned variant, and the name of the child that
+    /// was attempted to be accessed.
+    FieldAccessOnIndexedTyped(TcKey, V, HashSet<String>),
+    /// Attempted an indexed access to a child on a type that has named children.
+    /// Contains the affected key, its inferred or explicitly assigned variant, and the index of the child that
+    /// was attempted to be accessed.
+    IndexedAccessOnNamedType(TcKey, V, usize),
     /// This error occurs if the type checker inferred a specific arity but the variant reports a fixed arity that is lower than the inferred one.
     ArityMismatch {
         /// The key for which the mismatch was detected.
@@ -213,6 +226,19 @@ pub enum TcErr<V: ContextSensitiveVariant> {
         /// The arity required according to the meet operation that created the variant.
         reported_arity: usize,
     },
+    /// This error occurs if the type checker inferred a specific set of fields but the variant reports a fixed set of fields that is different than the inferred one.
+    FieldMismatch {
+        /// The key for which the mismatch was detected.
+        key: TcKey,
+        /// The variant with fixed arity.
+        variant: V,
+        /// The least required fields according to the type check procedure.
+        inferred_fields: HashSet<String>,
+        /// The fields required according to the meet operation that created the variant.
+        reported_fields: HashSet<String>,
+    },
+    /// The access kind of the types children did not match during a meet.
+    ChildKindMismatch(TcKey, V, TcKey, V),
     /// An error reporting a failed type construction.  Contains the affected key, the preliminary result for which the construction failed, and the
     /// error reported by the construction.
     Construction(TcKey, Preliminary<V>, V::Err),


### PR DESCRIPTION
This PR introduces named children. I.e. the children, or subtypes, of a type can now not only be accessed by index but also by name. This enables type checking for structs.
For this, a number of breaking changes were introduced to make handling these names as convenient as possible. Mainly, the arity now not only represents the number of children but can also be used to indicate the least set of child names (fields) a type should have.