### PR TITLE
Fix bug in constraint solver caused by lazy evaluation of `Result`

### DIFF
--- a/src/constraint_graph.rs
+++ b/src/constraint_graph.rs
@@ -422,7 +422,7 @@ impl<T: ContextSensitiveVariant> ConstraintGraph<T> {
 
                 Ok(change)
             })
-            .try_fold(false, |acc, chg| Ok(acc || chg?))
+            .try_fold(false, |acc, chg| Ok(acc | chg?))
     }
 
     #[must_use]


### PR DESCRIPTION
Fix a bug I just discovered: errors from `resolve_asymmetric()` must be returned even if there was a change, so use eager "or" (`|`) instead of short-circuiting "or" (`||`).